### PR TITLE
Add filter for -running- instances and fixed json format

### DIFF
--- a/StopExperiment.json
+++ b/StopExperiment.json
@@ -1,35 +1,43 @@
 {
     "tags": {
-         "Name": "StopAndRestartRandomeInstance"
+        "Name": "StopAndRestartRandomeInstance"
     },
     "description": "Stop and Restart One Random Instance",
-    "roleArn": "arn:aws:iam::<AccountID>:role/MyFISExperimentRole”,
+    "roleArn": "arn:aws:iam::<AccountID>:role/MyFISExperimentRole",
     "stopConditions": [
-         {
-             "source": "aws:cloudwatch:alarm",
-             "value": "arn:aws:cloudwatch:us-east-1:<AccountID>:alarm:No_Traffic"
-         }
+        {
+            "source": "aws:cloudwatch:alarm",
+            "value": "arn:aws:cloudwatch:us-east-1:<AccountID>:alarm:No_Traffic"
+        }
     ],
     "targets": {
-         "myInstance": {
-             "resourceTags": {
-                 "Env": "test"
-             },
-             "resourceType": "aws:ec2:instance",
-             "selectionMode": "COUNT(1)"
-         }
+        "myInstance": {
+            "resourceTags": {
+                "Env": "test"
+            },
+            "resourceType": "aws:ec2:instance",
+            "selectionMode": "COUNT(1)",
+            "filters": [
+                {
+                    "path": "State.Name",
+                    "values": [
+                        "running"
+                    ]
+                }
+            ]
+        }
     },
     "actions": {
-         "StopInstances": {
-             "actionId": "aws:ec2:stop-instances",
-             "description": "stop the instances",
-             "parameters": {
-                 "startInstancesAtEnd": "true",
-                 "duration": "PT2M",
-             },
-             "targets": {
-                 "Instances": "myInstance"
-             }
-         }
-     }
- } 
+        "StopInstances": {
+            "actionId": "aws:ec2:stop-instances",
+            "description": "stop the instances",
+            "parameters": {
+                "startInstancesAtEnd": "true",
+                "duration": "PT2M",
+            },
+            "targets": {
+                "Instances": "myInstance"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add filter to target running instances, otherwise FIS will target stopped and even terminated instances if still visible
- A closing quotes char was not the correct char (” instead of ")

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
