### PR TITLE
Bump CDK version, fix small cdk stack issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repo contains a CloudFormation (CFN) template with examples for AWS FIS. Ex
 
 ## Deployment
 
+You can either deploy via the provided CDK stack or use the synthesized CloudFormation YAML.
+
 The deployment will create 6 EC2 instances of type `t3a.nano` spread across two Availability Zones.
 
 To use the EKS experiment templates you will have to have a running EKS cluster. The creation of this cluster is out of scope of the CFN. However, you can create it easily with [eksctl](https://eksctl.io/) and the following example template (make sure to tweak the region accordingly):
@@ -33,7 +35,12 @@ managedNodeGroups:
     enableSsm: true
 ```
 
-Deploy via CLI:
+### Deploy via CDK:
+```bash
+cdk deploy
+```
+
+### Deploy via Cloudformation:
 
 ```bash
 aws cloudformation create-stack --template-body file://cfn_fis_demos.yaml --stack-name fis-demo-stack --capabilities CAPABILITY_NAMED_IAM
@@ -75,13 +82,9 @@ Delete the CloudFormation stack via CLI:
 aws cloudformation delete-stack --stack-name fis-demo-stack
 ```
 
-## CDK Resources
+## Generated CloudFormation YAML
 
-**Note** Initially this was supposed to be a CDK project. However, during development I came across an issue with the `@aws-cdk/aws-fis` CDK module (Version 1.102.0 at the time of writing).  
-Find my github issue here: [(aws-fis): MapProperties generate empty CFN output](https://github.com/aws/aws-cdk/issues/14309) 
-
-This is why I used CDK to create the baseline CloudFormation but then manually tweaked the resulting CFN to work around the mentioned issues.  
-I plan to move to CDK only again when the bugs are fixed in CDK. In the meantime be aware that the template synthesized by `cdk synth` will not work out-of-the-box and needs some work.
+The CFN YAML `cfn_fis_demos.yaml` is generated via CDK's `cdk synth > cfn_fis_demos.yaml` and should not be edited manually.
 
 
 ## Security

--- a/cfn_fis_demos.yaml
+++ b/cfn_fis_demos.yaml
@@ -1,3 +1,5 @@
+# THIS IS A GENERATED FILE ( cdk synth > cfn_fis_demos.yaml ).
+# DO NOT EDIT MANUALLY.
 Resources:
   vpcA2121C38:
     Type: AWS::EC2::VPC
@@ -329,7 +331,8 @@ Resources:
           - Fn::GetAZs: ""
       IamInstanceProfile:
         Ref: instance0InstanceProfile493621FA
-      ImageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      ImageId:
+        Ref: SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter
       InstanceType: t3a.nano
       SecurityGroupIds:
         - Fn::GetAtt:
@@ -381,7 +384,8 @@ Resources:
           - Fn::GetAZs: ""
       IamInstanceProfile:
         Ref: instance1InstanceProfileD4257E82
-      ImageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      ImageId:
+        Ref: SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter
       InstanceType: t3a.nano
       SecurityGroupIds:
         - Fn::GetAtt:
@@ -433,7 +437,8 @@ Resources:
           - Fn::GetAZs: ""
       IamInstanceProfile:
         Ref: instance2InstanceProfileB3658486
-      ImageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      ImageId:
+        Ref: SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter
       InstanceType: t3a.nano
       SecurityGroupIds:
         - Fn::GetAtt:
@@ -485,7 +490,8 @@ Resources:
           - Fn::GetAZs: ""
       IamInstanceProfile:
         Ref: instance3InstanceProfileDB6091B4
-      ImageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      ImageId:
+        Ref: SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter
       InstanceType: t3a.nano
       SecurityGroupIds:
         - Fn::GetAtt:
@@ -537,7 +543,8 @@ Resources:
           - Fn::GetAZs: ""
       IamInstanceProfile:
         Ref: instance4InstanceProfile12917602
-      ImageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      ImageId:
+        Ref: SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter
       InstanceType: t3a.nano
       SecurityGroupIds:
         - Fn::GetAtt:
@@ -589,7 +596,8 @@ Resources:
           - Fn::GetAZs: ""
       IamInstanceProfile:
         Ref: instance5InstanceProfile61D3A52E
-      ImageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      ImageId:
+        Ref: SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter
       InstanceType: t3a.nano
       SecurityGroupIds:
         - Fn::GetAtt:
@@ -755,10 +763,10 @@ Resources:
             - Path: State.Name
               Values:
                 - running
+          ResourceTags:
+            FIS-Target: "true"
           ResourceType: aws:ec2:instance
           SelectionMode: ALL
-          ResourceTags:
-            FIS-Target: true
       Actions:
         instanceActions:
           ActionId: aws:ec2:stop-instances
@@ -826,7 +834,7 @@ Resources:
       Targets:
         nodeGroupTarget:
           ResourceTags:
-            "eksctl.cluster.k8s.io/v1alpha1/cluster-name": eks-demo
+            eksctl.cluster.k8s.io/v1alpha1/cluster-name: eks-demo
           ResourceType: aws:eks:nodegroup
           SelectionMode: ALL
       Actions:
@@ -834,7 +842,7 @@ Resources:
           ActionId: aws:eks:terminate-nodegroup-instances
           Description: Terminate EKS NodeGroup Instance
           Parameters:
-            instanceTerminationPercentage: 50
+            instanceTerminationPercentage: "50"
           Targets:
             Nodegroups: nodeGroupTarget
     Metadata:
@@ -873,7 +881,7 @@ Resources:
                   - Ref: AWS::Region
                   - ::document/AWS-RunShellScript
             documentParameters: '{"commands":"sudo docker kill $(sudo docker ps -f name=k8s_ecsdemo-frontend -q)"}'
-            duration: PT2M
+            duration: PT1M
           Targets:
             Instances: workerNodesTarget
     Metadata:
@@ -881,10 +889,14 @@ Resources:
   CDKMetadata:
     Type: AWS::CDK::Metadata
     Properties:
-      Analytics: v2:deflate64:H4sIAAAAAAAAE11PQW6DMBB8S+6OE6Kq5yJURVwqC6LcjVkUJ2Ajex0aWf57bShF6mnHM+PdmYxmxxM97j74ZPeifRy80Aaor5GLB6nAamcEkEIri8YJJEWnNrZTUWglSq0CSRs8iBP111Ek7coKwlzTS1G7RsH8d0OVdggX3vSw8RuXW6uF5GnznzmBz5Kl8cXxzBEm/iLMyGeE2+JSIZiIV8OS5PeVYyx2G0AhKWMlrmKNGoQzEl9no904h/lPrNZAJB+or/QSep2rzIzuZKSYjp3nwwsKRPTatRNHcaM+77kZkjiDQDppaWr2PYKRKdkFhrGPcUMgSrdA7/bwzN5o9k6z3d1KuTdOYXTSapk/VBzM/cQBAAA=
+      Analytics: v2:deflate64:H4sIAAAAAAAAE11PQW6DMBB8S+6OE6qo56KoirhEFkS5L2ZRnICN7HVohPh7bSil6mnHM+PdmYQn+wPfbz6gd1tZPXaDNBb5UBDIB8vRGW8lsmOtBVhokdCyo9GOrJcU6b+WIFSKlNEji+sGlG98uHYyaldxZMKXjZKFLzVOf1eUG094gbLBlV+51DkjFcTNv+YIPjMRxxnoBIQ9vJiw6hngujjTIXHAi2FO8vNKKbS8taiJZaES6FCjQOmtotfJGt9NYf4Ti3VkClo+5GYOvcxFFtbUKlDChM7T4RmNTDbGVz2QvPEhbcC2UZzAyGrleGz21aFVMdkF264JcceRaVMhv7vdMznw5J0nm7tTamu9puDk+Ty/AWnNasbRAQAA
     Metadata:
       aws:cdk:path: FisExampleStack/CDKMetadata/Default
     Condition: CDKMetadataAvailable
+Parameters:
+  SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
 Conditions:
   CDKMetadataAvailable:
     Fn::Or:

--- a/lib/fis-example-stack.ts
+++ b/lib/fis-example-stack.ts
@@ -188,7 +188,7 @@ export class FisExampleStack extends cdk.Stack {
           parameters: {
             instanceTerminationPercentage: "50"
           },
-          targets: { NodeGroups: 'nodeGroupTarget' }
+          targets: { Nodegroups: 'nodeGroupTarget' }
         }
       },
       targets: {
@@ -210,7 +210,7 @@ export class FisExampleStack extends cdk.Stack {
       parameters: {
         documentArn: `arn:aws:ssm:${this.region}::document/AWS-RunShellScript`,
         documentParameters: JSON.stringify(
-            { commands: [killContainerScript]} ),
+            { commands: killContainerScript} ),
         duration: 'PT1M'
       },
       targets: { Instances: 'workerNodesTarget' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,160 +5,160 @@
   "requires": true,
   "dependencies": {
     "@aws-cdk/assert": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-1.102.0.tgz",
-      "integrity": "sha512-/NWjkg1ULpoUzEnIoxDjWverPbLx112UMydEDq3dwadxlsCQTijbIqot+oDWfmeDpmLOLTdLa5BROVm6mpbirQ==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-1.104.0.tgz",
+      "integrity": "sha512-7cwUnA3vq0NOpoYcajV8HZ9oH2nCCIm9Ty0UgPFGVlkpgpnfav8DfAIotp42dyn/1DeUNIAWv+oOpjn9MfZTdQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloudformation-diff": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
+        "@aws-cdk/cloudformation-diff": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/assets": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.102.0.tgz",
-      "integrity": "sha512-vmbEeHIIWTJT2KPl17afHN5aBIcstQbYlnMDF2BhUJ2famiIcadh2lWnH+BVDWfI4HoOhO68te2MhmW12VIYyg==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.104.0.tgz",
+      "integrity": "sha512-db5M8Vknw+xIVPdlR+brpmCMIsltKb5w4DNhTVTpfD6VZSyD5gG1TmGUTZKE/icj1YERzQCUbZ85E/Mtd2cV8w==",
       "requires": {
-        "@aws-cdk/core": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
+        "@aws-cdk/core": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-cloudwatch": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.102.0.tgz",
-      "integrity": "sha512-cwscvV1sgn+LhaGSz5vKXrivKBSY4EcQbUwWPUeuk/X0Wk3vkoLmgY0ma5hNgNuXJAoha6V/GzJgXdNKXLofdw==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.104.0.tgz",
+      "integrity": "sha512-0BpT5AOMZIhH4MyiETZzL/Y2ElbhtsPKl0I4RkzAFGby7H4DtsHTbn5PokZa+cRWGhH3XD2bauSUseQlsSAqYg==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ec2": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.102.0.tgz",
-      "integrity": "sha512-2tS3uXOVohHaDXBl/hvzl6n3iPoB3//hJhCW+BV9x6GOPHHyHT4otGi8l9JrgNwQ/w0QyZ3TbNwbqCvuK2KFmA==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.104.0.tgz",
+      "integrity": "sha512-PyAIEI1Ae2AOHDXh2G2JAMVbBgJk9lueRiE+eGsn5yc2lDTtncjDFAamYJ4HEIcsOUBygm5OwvxVRZpJVOTqBw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.102.0",
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/aws-kms": "1.102.0",
-        "@aws-cdk/aws-logs": "1.102.0",
-        "@aws-cdk/aws-s3": "1.102.0",
-        "@aws-cdk/aws-s3-assets": "1.102.0",
-        "@aws-cdk/aws-ssm": "1.102.0",
-        "@aws-cdk/cloud-assembly-schema": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
-        "@aws-cdk/region-info": "1.102.0",
+        "@aws-cdk/aws-cloudwatch": "1.104.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/aws-kms": "1.104.0",
+        "@aws-cdk/aws-logs": "1.104.0",
+        "@aws-cdk/aws-s3": "1.104.0",
+        "@aws-cdk/aws-s3-assets": "1.104.0",
+        "@aws-cdk/aws-ssm": "1.104.0",
+        "@aws-cdk/cloud-assembly-schema": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
+        "@aws-cdk/region-info": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-events": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.102.0.tgz",
-      "integrity": "sha512-d5LyvkEABbNb7eYN1CycItMAR/4xBZFiX3OPKCE+gUMPGxQkIxvWgtyQMF5/i0ODvABdKaRuF7DN2a7MP3tLoA==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.104.0.tgz",
+      "integrity": "sha512-zn0uqVPc8ZVAcKLa8JJaRrKB4a6f8fi0p/j3bEsSAiojv1zm2bT8whXBq9qpMU3HraRp2dQkwpiNHUYf3F0zfA==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-fis": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-fis/-/aws-fis-1.102.0.tgz",
-      "integrity": "sha512-/4YQhnfAsxoXABTmjQWfAE/YpeqprDkRYZGcCc/dI1U1MzFoeCSrp54GwRoAQel02RFK5nDS8FCa2701kwIgDw==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-fis/-/aws-fis-1.104.0.tgz",
+      "integrity": "sha512-qTyG4YHzAhgXAgOXbVGGdVdozqPhB/5WYfkWH8HGCSTfBVIMk8T2AFZSlgNP9fYtpjCVUZQ1wjNOotTiNsh5yQ==",
       "requires": {
-        "@aws-cdk/core": "1.102.0"
+        "@aws-cdk/core": "1.104.0"
       }
     },
     "@aws-cdk/aws-iam": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.102.0.tgz",
-      "integrity": "sha512-rA+WtNT5g9ad3RZop9H4+bXd8U6LW9vP0P/Ko/zTQKPTRKv0Xm1kKyQtlRaKpj5rRxj4CgwAl7Dhr2ezWLEK6Q==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.104.0.tgz",
+      "integrity": "sha512-lqpbad/RwwI8RtRvF6Tqz8R9WLjuYnwlt1MzLbHXzJUhjwkYC6YAXIPytHBaK9QvQKhEZVbLHWAXVzojZ8oYTQ==",
       "requires": {
-        "@aws-cdk/core": "1.102.0",
-        "@aws-cdk/region-info": "1.102.0",
+        "@aws-cdk/core": "1.104.0",
+        "@aws-cdk/region-info": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-kms": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.102.0.tgz",
-      "integrity": "sha512-cTZKN9Uv5bXp7xYmxQveGT/q6ScgWym0J/L6om+GRXHUIM/VWkvBKeiPMLBrLRKS87mH3r+TI3cukhSrTNeRMg==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.104.0.tgz",
+      "integrity": "sha512-qc88mLw130VR/wJAxTmcq3dtzzv4EkUrmFq33W9BDrNwOEPCu5Qfz0alIFjrkT87a/Nk4sD1+LIwwWXnlWkdww==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-logs": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.102.0.tgz",
-      "integrity": "sha512-QCB3R1EIcfrpktzQczoGGBQxfscvhFi72+7lto+Tq7+Vv7MlUGJADAyYOgr/fZNDoFNulfDCL+LOMTWVnvUwQg==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.104.0.tgz",
+      "integrity": "sha512-3cvM7MxKDqXV1BGHnMTO3JyHg+7QKgFs4ncUh1vxHNsjVFyV6ZPmEdiQxDhVfT9ZuIh+tDc5I5G7KfK79UbuQA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.102.0",
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/aws-kms": "1.102.0",
-        "@aws-cdk/aws-s3-assets": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
+        "@aws-cdk/aws-cloudwatch": "1.104.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/aws-kms": "1.104.0",
+        "@aws-cdk/aws-s3-assets": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-s3": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.102.0.tgz",
-      "integrity": "sha512-X5ziLXUl3i9GCLItk77E2j7UXnC08j125FiWwJksmb8cnKUolBzpfV91jTGhenwoho51KAhFgpKsb11fuvBylA==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.104.0.tgz",
+      "integrity": "sha512-yzH9FPufRYyJ3UHCEgfb1u8laSEuKv2F5g5yKjROJOAB0SVsBX2xoXcJV3JTuaSTrEYOJCNKEGTbYGSnYS3Ccw==",
       "requires": {
-        "@aws-cdk/aws-events": "1.102.0",
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/aws-kms": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
+        "@aws-cdk/aws-events": "1.104.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/aws-kms": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-s3-assets": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.102.0.tgz",
-      "integrity": "sha512-3RW03TqOKIzz6vZ2HgsX7Yo52SWtgZ+OsffXXK99ywM8hBZoDjg3kXtr3xBIWX91HC5tiMAKrkUsh8JoDiSu5g==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.104.0.tgz",
+      "integrity": "sha512-X+GWL+k2Ph16DFa/eJk4LwYojd14z4JvVpcddCk4n5SeSbkRJoQEQEMtnb4VcWW045c9jq/qbc9wHrKAx1P1xg==",
       "requires": {
-        "@aws-cdk/assets": "1.102.0",
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/aws-kms": "1.102.0",
-        "@aws-cdk/aws-s3": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
+        "@aws-cdk/assets": "1.104.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/aws-kms": "1.104.0",
+        "@aws-cdk/aws-s3": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ssm": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.102.0.tgz",
-      "integrity": "sha512-tgYYYMrk6oCditiCHvB401jv6508mv/zhZDNAHh3VfE+/FpbgdtJhiLpPu6+jitRSWMeg5ZPfUCSyaiojVvX+Q==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.104.0.tgz",
+      "integrity": "sha512-yfyKeeo2x7i5efSQ9RIcreahhV2Bs5QVwGIKbGRKqGnyus5+hhuCvLDhJicNdrkQ9wJPbmmNO0rR3SQjsZeteg==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.102.0",
-        "@aws-cdk/aws-kms": "1.102.0",
-        "@aws-cdk/cloud-assembly-schema": "1.102.0",
-        "@aws-cdk/core": "1.102.0",
+        "@aws-cdk/aws-iam": "1.104.0",
+        "@aws-cdk/aws-kms": "1.104.0",
+        "@aws-cdk/cloud-assembly-schema": "1.104.0",
+        "@aws-cdk/core": "1.104.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/cfnspec": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.102.0.tgz",
-      "integrity": "sha512-ANISPQax3v00vzApzc5PRsTJJPlajPU7h5yXclxu8WN8/wgSiJYbZOPhhsumAROM10Ck8oDTc6SOd+8EXpfhtQ==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.104.0.tgz",
+      "integrity": "sha512-kM/94UhlrM+QqQPa2dxIxy9hqsegNrOMQVq/inq+gqXYkMvfepL74A8HVgjJto6vZnM50Hbjnd71Imo6SDBhpg==",
       "dev": true,
       "requires": {
         "md5": "^2.3.0"
       }
     },
     "@aws-cdk/cloud-assembly-schema": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.102.0.tgz",
-      "integrity": "sha512-fOHjBc5/vp+rEPEXAZXuexU6emMan30dPWfecTLPE4pXa1bEWgiV9FtPCFAlRfNPXyWr4pBoD97Dy7daK1KC+w==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.104.0.tgz",
+      "integrity": "sha512-4tutOtghEcgWc9La/c14tuohHrilq/Y9Y8wG7GWPq8SlXi64R3qdcspYqrNacXWNKoIeShjhtX4NKbYJkMOu9w==",
       "requires": {
         "jsonschema": "^1.4.0",
         "semver": "^7.3.5"
@@ -189,27 +189,27 @@
       }
     },
     "@aws-cdk/cloudformation-diff": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.102.0.tgz",
-      "integrity": "sha512-bdvlN+FFYHinZ6BJfOsNWmoHkdduEZQkw4cD76cCUNGULxJOKIjEdlghNoNtoeUKSZMgW7eenfgHImA1YHJrrQ==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.104.0.tgz",
+      "integrity": "sha512-+ThxV2cQ5paeDaMVrU5VX8nmnLX8UsAMOud1IY9RRaDcCnJRvfPSec//wrv8WST/X6bWcoGD07i8xUM7senbGA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cfnspec": "1.102.0",
+        "@aws-cdk/cfnspec": "1.104.0",
         "colors": "^1.4.0",
         "diff": "^5.0.0",
         "fast-deep-equal": "^3.1.3",
         "string-width": "^4.2.2",
-        "table": "^6.3.0"
+        "table": "^6.7.0"
       }
     },
     "@aws-cdk/core": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.102.0.tgz",
-      "integrity": "sha512-r4YHNTivzZ4xYSqQuH+FnDjU22fbJtSXyC8thDXy+oGXJfxJPZ3zQQM2oapLimpB1WokjFQdm7mHsIGulq/gFg==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.104.0.tgz",
+      "integrity": "sha512-GAt9lf1yF4jt2nSKHhjaD4/6GaE+IqRtHMVC4ZL/T3wJ2V1jZWgG5oE2PATylRZkGBoQXTIu7IfM4tg0AKqHPA==",
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
-        "@aws-cdk/region-info": "1.102.0",
+        "@aws-cdk/cloud-assembly-schema": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
+        "@aws-cdk/region-info": "1.104.0",
         "@balena/dockerignore": "^1.0.2",
         "constructs": "^3.3.69",
         "fs-extra": "^9.1.0",
@@ -226,7 +226,7 @@
           "bundled": true
         },
         "balanced-match": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true
         },
         "brace-expansion": {
@@ -281,11 +281,11 @@
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.102.0.tgz",
-      "integrity": "sha512-OFpSFYaTsUKdDS7KejOzeHEGzh2fMpPFps8nnZNMaP6LEdNdEkH1xvD6/VRvReQRQB3t5tgNb0pJiRUvMbVgSQ==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.104.0.tgz",
+      "integrity": "sha512-sqWMLmGnGZSeXcDifKT+9GmMtqLcz+lAnac3iHvh9Q32fQD0Mfh0U34+xWbwIeSTz32AE6yo2h2rsY9BrRlutA==",
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.102.0",
+        "@aws-cdk/cloud-assembly-schema": "1.104.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
@@ -310,9 +310,9 @@
       }
     },
     "@aws-cdk/region-info": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.102.0.tgz",
-      "integrity": "sha512-zPL04Kx3Vxkb33hRONHeiRCZwX9ko7FVBUDSl7FM1m2XnAz1EgyldhwDe9ndHp4b8YCscUUR201OLxPJP+5qTg=="
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.104.0.tgz",
+      "integrity": "sha512-HecPbcLVWW4Br4WOOI6Q8IvrYEPy7dCw+YozBi2kXOhwWu9GZE8+goP9fqOkxvFtLpOrcfO/jsNBHq7KNTlUtw=="
     },
     "@babel/code-frame": {
       "version": "7.12.13",
@@ -1132,9 +1132,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
-      "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
+      "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -1264,30 +1264,30 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.102.0.tgz",
-      "integrity": "sha512-Fs4MEm9aw0l7YAyNDQbYwkcK6RzkDRvwX/SMgb4BthoyD45dk8ZjkL6CaJfgP15dLF3NpgHbkuTiwRKIy32kyw==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.104.0.tgz",
+      "integrity": "sha512-ABpIZo8u7JxnPn7rIOaK6LgsVWLTdCUyy0kszPalEjY1SQaKllj6BfK+Z2YsCk2sV+E8k5VdX5QByAnJJyxZgw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.102.0",
-        "@aws-cdk/cloudformation-diff": "1.102.0",
-        "@aws-cdk/cx-api": "1.102.0",
-        "@aws-cdk/region-info": "1.102.0",
+        "@aws-cdk/cloud-assembly-schema": "1.104.0",
+        "@aws-cdk/cloudformation-diff": "1.104.0",
+        "@aws-cdk/cx-api": "1.104.0",
+        "@aws-cdk/region-info": "1.104.0",
         "archiver": "^5.3.0",
         "aws-sdk": "^2.848.0",
         "camelcase": "^6.2.0",
-        "cdk-assets": "1.102.0",
+        "cdk-assets": "1.104.0",
         "colors": "^1.4.0",
         "decamelize": "^5.0.0",
         "fs-extra": "^9.1.0",
-        "glob": "^7.1.6",
+        "glob": "^7.1.7",
         "json-diff": "^0.5.4",
         "minimatch": ">=3.0",
         "promptly": "^3.2.0",
         "proxy-agent": "^4.0.1",
         "semver": "^7.3.5",
         "source-map-support": "^0.5.19",
-        "table": "^6.1.0",
+        "table": "^6.7.0",
         "uuid": "^8.3.2",
         "wrap-ansi": "^7.0.0",
         "yaml": "1.10.2",
@@ -1295,18 +1295,18 @@
       },
       "dependencies": {
         "@aws-cdk/cfnspec": {
-          "version": "1.102.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.102.0.tgz",
-          "integrity": "sha512-ANISPQax3v00vzApzc5PRsTJJPlajPU7h5yXclxu8WN8/wgSiJYbZOPhhsumAROM10Ck8oDTc6SOd+8EXpfhtQ==",
+          "version": "1.104.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.104.0.tgz",
+          "integrity": "sha512-kM/94UhlrM+QqQPa2dxIxy9hqsegNrOMQVq/inq+gqXYkMvfepL74A8HVgjJto6vZnM50Hbjnd71Imo6SDBhpg==",
           "dev": true,
           "requires": {
             "md5": "^2.3.0"
           }
         },
         "@aws-cdk/cloud-assembly-schema": {
-          "version": "1.102.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.102.0.tgz",
-          "integrity": "sha512-fOHjBc5/vp+rEPEXAZXuexU6emMan30dPWfecTLPE4pXa1bEWgiV9FtPCFAlRfNPXyWr4pBoD97Dy7daK1KC+w==",
+          "version": "1.104.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.104.0.tgz",
+          "integrity": "sha512-4tutOtghEcgWc9La/c14tuohHrilq/Y9Y8wG7GWPq8SlXi64R3qdcspYqrNacXWNKoIeShjhtX4NKbYJkMOu9w==",
           "dev": true,
           "requires": {
             "jsonschema": "^1.4.0",
@@ -1314,52 +1314,33 @@
           }
         },
         "@aws-cdk/cloudformation-diff": {
-          "version": "1.102.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.102.0.tgz",
-          "integrity": "sha512-bdvlN+FFYHinZ6BJfOsNWmoHkdduEZQkw4cD76cCUNGULxJOKIjEdlghNoNtoeUKSZMgW7eenfgHImA1YHJrrQ==",
+          "version": "1.104.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.104.0.tgz",
+          "integrity": "sha512-+ThxV2cQ5paeDaMVrU5VX8nmnLX8UsAMOud1IY9RRaDcCnJRvfPSec//wrv8WST/X6bWcoGD07i8xUM7senbGA==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cfnspec": "1.102.0",
+            "@aws-cdk/cfnspec": "1.104.0",
             "colors": "^1.4.0",
             "diff": "^5.0.0",
             "fast-deep-equal": "^3.1.3",
             "string-width": "^4.2.2",
-            "table": "^6.3.0"
-          },
-          "dependencies": {
-            "table": {
-              "version": "6.3.2",
-              "resolved": "https://registry.yarnpkg.com/table/-/table-6.3.2.tgz#afa86bee5cfe305f9328f89bb3e5454132cdea28",
-              "integrity": "sha512-I9/Ca6Huf2oxFag7crD0DhA+arIdfLtWunSn0NIXSzjtUlDgIBGVZY7SsMkNPNT3Psd/z4gza0nuEpmra9eRbg==",
-              "dev": true,
-              "requires": {
-                "ajv": "^8.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.truncate": "^4.4.2",
-                "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.0"
-              }
-            }
+            "table": "^6.7.0"
           }
         },
         "@aws-cdk/cx-api": {
-          "version": "1.102.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.102.0.tgz",
-          "integrity": "sha512-OFpSFYaTsUKdDS7KejOzeHEGzh2fMpPFps8nnZNMaP6LEdNdEkH1xvD6/VRvReQRQB3t5tgNb0pJiRUvMbVgSQ==",
+          "version": "1.104.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.104.0.tgz",
+          "integrity": "sha512-sqWMLmGnGZSeXcDifKT+9GmMtqLcz+lAnac3iHvh9Q32fQD0Mfh0U34+xWbwIeSTz32AE6yo2h2rsY9BrRlutA==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cloud-assembly-schema": "1.102.0",
+            "@aws-cdk/cloud-assembly-schema": "1.104.0",
             "semver": "^7.3.5"
           }
         },
         "@aws-cdk/region-info": {
-          "version": "1.102.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.102.0.tgz",
-          "integrity": "sha512-zPL04Kx3Vxkb33hRONHeiRCZwX9ko7FVBUDSl7FM1m2XnAz1EgyldhwDe9ndHp4b8YCscUUR201OLxPJP+5qTg==",
+          "version": "1.104.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.104.0.tgz",
+          "integrity": "sha512-HecPbcLVWW4Br4WOOI6Q8IvrYEPy7dCw+YozBi2kXOhwWu9GZE8+goP9fqOkxvFtLpOrcfO/jsNBHq7KNTlUtw==",
           "dev": true
         },
         "@tootallnate/once": {
@@ -1378,9 +1359,9 @@
           }
         },
         "ajv": {
-          "version": "8.0.2",
-          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.0.2.tgz#1396e27f208ed56dd5638ab5a251edeb1c91d402",
-          "integrity": "sha512-V0HGxJd0PiDF0ecHYIesTOqfd1gJguwQUOYfMfAWnRsWQEXfc5ifbUFhD3Wjc+O+y7VAqL+g07prq9gHQ/JOZQ==",
+          "version": "8.3.0",
+          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.3.0.tgz#25ee7348e32cdc4a1dbb38256bf6bdc451dd577c",
+          "integrity": "sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -1482,9 +1463,9 @@
           "dev": true
         },
         "aws-sdk": {
-          "version": "2.866.0",
-          "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.866.0.tgz#8150fb2e0cfecd281968edee7cad84598d8d7a09",
-          "integrity": "sha512-6Z581Ek2Yfm78NpeEFMNuSoyiYG7tipEaqfWNFR1AGyYheZwql4ajhzzlpWn91LBpdm7qcFldSNY9U0tKpKWNw==",
+          "version": "2.903.0",
+          "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.903.0.tgz#4c8252723370ebbdaffe69f4dfddc5973b1dab4a",
+          "integrity": "sha512-BP/giYLP8QJ63Jta59kph1F76oPITxRt/wNr3BdoEs9BtshWlGKk149UaseDB4wJtI+0TER5jtzBIUBcP6E+wA==",
           "dev": true,
           "requires": {
             "buffer": "4.9.2",
@@ -1532,9 +1513,9 @@
           }
         },
         "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "version": "1.0.2",
+          "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
           "dev": true
         },
         "base64-js": {
@@ -1592,16 +1573,6 @@
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
           "dev": true
         },
-        "call-bind": {
-          "version": "1.0.2",
-          "resolved": "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c",
-          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2"
-          }
-        },
         "camelcase": {
           "version": "6.2.0",
           "resolved": "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809",
@@ -1609,16 +1580,16 @@
           "dev": true
         },
         "cdk-assets": {
-          "version": "1.102.0",
-          "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-1.102.0.tgz",
-          "integrity": "sha512-W7MawapluvfGDwZvxo/JfbM7+N6lGgBdK5bdhBva0oFtIThJ4TwyWQRiY/H5q6Svk2xr00T8xtaFSbkZmfnQ0A==",
+          "version": "1.104.0",
+          "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-1.104.0.tgz",
+          "integrity": "sha512-epQx2kcD2rqRqLxJOVsEM4tP3vQQhYF+9oyQu3qC8IuKSpnYpyqSH5wx7cWSGRx6yzVKvrVYr441SUWGGJi9QA==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cloud-assembly-schema": "1.102.0",
-            "@aws-cdk/cx-api": "1.102.0",
+            "@aws-cdk/cloud-assembly-schema": "1.104.0",
+            "@aws-cdk/cx-api": "1.104.0",
             "archiver": "^5.3.0",
             "aws-sdk": "^2.848.0",
-            "glob": "^7.1.6",
+            "glob": "^7.1.7",
             "yargs": "^16.2.0"
           }
         },
@@ -1935,28 +1906,11 @@
             }
           }
         },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-          "dev": true
-        },
         "get-caller-file": {
           "version": "2.0.5",
           "resolved": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e",
           "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
-        },
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "resolved": "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6",
-          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
-          }
         },
         "get-uri": {
           "version": "3.0.2",
@@ -2001,9 +1955,9 @@
           }
         },
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "7.1.7",
+          "resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2018,21 +1972,6 @@
           "version": "4.2.6",
           "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee",
           "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-          "dev": true
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
           "dev": true
         },
         "heap": {
@@ -2112,15 +2051,6 @@
           "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "dev": true
         },
-        "is-boolean-object": {
-          "version": "1.1.0",
-          "resolved": "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0",
-          "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0"
-          }
-        },
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
@@ -2131,18 +2061,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "is-number-object": {
-          "version": "1.0.4",
-          "resolved": "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197",
-          "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-          "dev": true
-        },
-        "is-string": {
-          "version": "1.0.5",
-          "resolved": "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6",
-          "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
           "dev": true
         },
         "isarray": {
@@ -2310,9 +2228,9 @@
           "dev": true
         },
         "netmask": {
-          "version": "2.0.1",
-          "resolved": "https://registry.yarnpkg.com/netmask/-/netmask-2.0.1.tgz#5a5cbdcbb7b6de650870e15e83d3e9553a414cf4",
-          "integrity": "sha512-gB8eG6ubxz67c7O2gaGiyWdRUIbH61q7anjgueDqCC9kvIs/b4CTtCMaQKeJbv1/Y7FT19I4zKwYmjnjInRQsg==",
+          "version": "2.0.2",
+          "resolved": "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7",
+          "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
           "dev": true
         },
         "normalize-path": {
@@ -2577,9 +2495,9 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.0",
-          "resolved": "https://registry.yarnpkg.com/socks/-/socks-2.6.0.tgz#6b984928461d39871b3666754b9000ecf39dfac2",
-          "integrity": "sha512-mNmr9owlinMplev0Wd7UHFlqI4ofnBnNzFuzrm63PPaHgbkqCFe4T5LzwKmtQ/f2tX0NTpcdVLyD/FHxFBstYw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e",
+          "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
           "dev": true,
           "requires": {
             "ip": "^1.1.5",
@@ -2649,20 +2567,17 @@
           }
         },
         "table": {
-          "version": "6.1.0",
-          "resolved": "https://registry.yarnpkg.com/table/-/table-6.1.0.tgz#676a0cfb206008b59e783fcd94ef8ba7d67d966c",
-          "integrity": "sha512-T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==",
+          "version": "6.7.0",
+          "resolved": "https://registry.yarnpkg.com/table/-/table-6.7.0.tgz#26274751f0ee099c547f6cb91d3eff0d61d155b2",
+          "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
           "dev": true,
           "requires": {
             "ajv": "^8.0.1",
-            "is-boolean-object": "^1.1.0",
-            "is-number-object": "^1.0.4",
-            "is-string": "^1.0.5",
             "lodash.clonedeep": "^4.5.0",
-            "lodash.flatten": "^4.4.0",
             "lodash.truncate": "^4.4.2",
             "slice-ansi": "^4.0.0",
-            "string-width": "^4.2.0"
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "tar-stream": {
@@ -2685,9 +2600,9 @@
           "dev": true
         },
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "version": "2.2.0",
+          "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         },
         "type-check": {
@@ -2810,9 +2725,9 @@
           "dev": true
         },
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "version": "5.0.8",
+          "resolved": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
           "dev": true
         },
         "yallist": {
@@ -5047,12 +4962,6 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -6406,14 +6315,13 @@
       "dev": true
     },
     "table": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
-      "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.clonedeep": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.102.0",
+    "@aws-cdk/assert": "1.104.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.102.0",
+    "aws-cdk": "1.104.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-cloudwatch": "^1.102.0",
-    "@aws-cdk/aws-ec2": "^1.102.0",
-    "@aws-cdk/aws-fis": "^1.102.0",
-    "@aws-cdk/aws-iam": "^1.102.0",
-    "@aws-cdk/core": "1.102.0",
+    "@aws-cdk/aws-cloudwatch": "^1.104.0",
+    "@aws-cdk/aws-ec2": "^1.104.0",
+    "@aws-cdk/aws-fis": "^1.104.0",
+    "@aws-cdk/aws-iam": "^1.104.0",
+    "@aws-cdk/core": "1.104.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Description of changes:*

With the release of CDK 1.104.0 the issue https://github.com/aws/aws-cdk/issues/14309 is fixed and we can now move to full CDK (i.e. not manually editing the CFN template after `cdk synth`).

Bumping to latest CDK, fixing some minor issues in CDK stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
